### PR TITLE
Fix go-get-tool in Makefile

### DIFF
--- a/.github/workflows/validate-ipfs.yaml
+++ b/.github/workflows/validate-ipfs.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["main", "release*"]
 
 env:
-  GO_VERSION: "1.17"
+  GO_VERSION: "1.18"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/redhat-et-ipfs/ipfs-operator"
   BUNDLE_IMAGE: "quay.io/redhat-et-ipfs/ipfs-operator-bundle"

--- a/Makefile
+++ b/Makefile
@@ -176,9 +176,8 @@ define go-get-tool
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
-go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest


### PR DESCRIPTION
From go1.17 applications should be installed using `go install`.

The current way does not work starting with go1.18.