### PR TITLE
Add metallb to KIND install script

### DIFF
--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -21,6 +21,3 @@ case "${1:-}" in
     install_metallb
   ;;
 esac
-
-# check_kind
-# setup_kind_cluster

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -1,111 +1,8 @@
 #!/bin/bash
-
 set -e -o pipefail
 
-#######################################
-# Makes sure that the KIND command is 
-# installed before continuing.
-#
-# Globals:
-#  None
-# Arguments:
-#  None
-# Returns:
-#  None
-#######################################
-function check_kind() {
-  if ! command -v kind >/dev/null 2>&1; then
-    echo "kind is not installed. Please install kind before running this script."
-    exit 1
-  else 
-    echo "kind is installed, ready to Go :)"
-  fi
-}
-
-######################################
-# Installs MetalLB into the default namespace
-# for the current cluster.
-# Globals:
-#  None
-# Arguments:
-#  None
-# Returns:
-#  1 if MetalLB is not installed, 0 otherwise
-######################################
-function install_metallb() {
-  local metalLBVersion='v0.12.1'
-  local metalLBManifests="https://raw.githubusercontent.com/metallb/metallb/${metalLBVersion}/manifests"
-  local metalLBNamespaceURL="${metalLBManifests}/namespace.yaml"
-  local metalLBURL="${metalLBManifests}/metallb.yaml"
-  local metalLBNamespace="metallb-system"
-
-  # create the metallb namespace
-  if ! [[ $(kubectl apply -f "${metalLBNamespaceURL}") ]]; then
-    echo "Failed to create metallb namespace"
-    return 1
-  fi
-
-  # create the manifest
-  if ! [[ $(kubectl apply -f "${metalLBURL}") ]]; then
-    echo "Failed to create metallb manifest"
-    return 1
-  fi
-
-  # wait for all pods with the label 'app=metallb' to be ready
-  echo "📦 waiting for pods to be ready..."
-  kubectl wait --for=condition=ready pod -l app=metallb -n "${metalLBNamespace}"
-  echo "✅ pods are ready"
-
-  # allocate a group of subnets to be used for the MetalLB instances
-  local ipamConfig=$(docker network inspect -f '{{.IPAM.Config}}' kind)
-  local subnet=$(echo "${ipamConfig}" | awk '{ print $1 }')
-  local regex="([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/([0-9]+)"
-  if ! [[ $subnet =~ $regex ]]; then
-    echo "could not match"
-  fi
-
-  # create the subnets in MetalLB
-  local net1="${BASH_REMATCH[1]}"
-  local net2="${BASH_REMATCH[2]}"
-  local net3="${BASH_REMATCH[3]}"
-  local net4="${BASH_REMATCH[4]}"
-  local subnetMask="${BASH_REMATCH[5]}"
-
-  if ! [[ "${subnetMask}" -eq "16" ]]; then
-    echo "subnet unsupported"
-    return 1
-  fi
-
-  # create a single subnet
-  cat <<END | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: metallb-system
-  name: config
-data:
-  config: |
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
-      - ${net1}.${net2}.255.200-${net1}.${net2}.255.250
-END
-}
-
-#######################################
-# Creates a new cluster with kind.
-# Globals:
-#  CLUSTER_NAME
-# Arguments:
-#  None
-# Returns:
-#  None
-#######################################
-function setup_kind_cluster() {
-  # create the kind cluster if it doesn't already exist
-  kind create cluster --name "${CLUSTER_NAME:-kind}"
-}
+# imports utils
+source ./hack/utils.sh
 
 # run commands or install
 case "${1:-}" in
@@ -113,13 +10,16 @@ case "${1:-}" in
     check_kind
     ;;
   "metallb")
-    echo "installing metallb"
+    echo "installing metallb..."
     install_metallb
-    echo "✅ metallb installed"
+    echo "✅ installed"
     ;;
   *)
-    setup_kind_cluster
-    ;;
+    check_cmd docker kind kubectl
+    echo "Setting up a kind cluster"
+    kind create cluster --name "${CLUSTER_NAME:-kind}"
+    install_metallb
+  ;;
 esac
 
 # check_kind

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -7,16 +7,18 @@ source ./hack/utils.sh
 # run commands or install
 case "${1:-}" in
   "check")
-    check_kind
+    log "Checking for required commands"
+    check_cmd docker kind kubectl
+    log "All required commands are installed"
     ;;
   "metallb")
-    echo "installing metallb..."
+    log "Installing metallb..."
     install_metallb
-    echo "✅ installed"
+    log "✅ installed"
     ;;
   *)
     check_cmd docker kind kubectl
-    echo "Setting up a kind cluster"
+    log "Setting up a kind cluster"
     kind create cluster --name "${CLUSTER_NAME:-kind}"
     install_metallb
   ;;

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -14,12 +14,83 @@ set -e -o pipefail
 #  None
 #######################################
 function check_kind() {
-	if ! command -v kind >/dev/null 2>&1; then
-		echo "kind is not installed. Please install kind before running this script."
-		exit 1
-	else 
-		echo "kind is installed, ready to Go :)"
-	fi
+  if ! command -v kind >/dev/null 2>&1; then
+    echo "kind is not installed. Please install kind before running this script."
+    exit 1
+  else 
+    echo "kind is installed, ready to Go :)"
+  fi
+}
+
+######################################
+# Installs MetalLB into the default namespace
+# for the current cluster.
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  1 if MetalLB is not installed, 0 otherwise
+######################################
+function install_metallb() {
+  local metalLBVersion='v0.12.1'
+  local metalLBManifests="https://raw.githubusercontent.com/metallb/metallb/${metalLBVersion}/manifests"
+  local metalLBNamespaceURL="${metalLBManifests}/namespace.yaml"
+  local metalLBURL="${metalLBManifests}/metallb.yaml"
+  local metalLBNamespace="metallb-system"
+
+  # create the metallb namespace
+  if ! [[ $(kubectl apply -f "${metalLBNamespaceURL}") ]]; then
+    echo "Failed to create metallb namespace"
+    return 1
+  fi
+
+  # create the manifest
+  if ! [[ $(kubectl apply -f "${metalLBURL}") ]]; then
+    echo "Failed to create metallb manifest"
+    return 1
+  fi
+
+  # wait for all pods with the label 'app=metallb' to be ready
+  echo "📦 waiting for pods to be ready..."
+  kubectl wait --for=condition=ready pod -l app=metallb -n "${metalLBNamespace}"
+  echo "✅ pods are ready"
+
+  # allocate a group of subnets to be used for the MetalLB instances
+  local ipamConfig=$(docker network inspect -f '{{.IPAM.Config}}' kind)
+  local subnet=$(echo "${ipamConfig}" | awk '{ print $1 }')
+  local regex="([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/([0-9]+)"
+  if ! [[ $subnet =~ $regex ]]; then
+    echo "could not match"
+  fi
+
+  # create the subnets in MetalLB
+  local net1="${BASH_REMATCH[1]}"
+  local net2="${BASH_REMATCH[2]}"
+  local net3="${BASH_REMATCH[3]}"
+  local net4="${BASH_REMATCH[4]}"
+  local subnetMask="${BASH_REMATCH[5]}"
+
+  if ! [[ "${subnetMask}" -eq "16" ]]; then
+    echo "subnet unsupported"
+    return 1
+  fi
+
+  # create a single subnet
+  cat <<END | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - ${net1}.${net2}.255.200-${net1}.${net2}.255.250
+END
 }
 
 #######################################
@@ -32,8 +103,24 @@ function check_kind() {
 #  None
 #######################################
 function setup_kind_cluster() {
-	kind create cluster --name "${CLUSTER_NAME:-kind}"
+  # create the kind cluster if it doesn't already exist
+  kind create cluster --name "${CLUSTER_NAME:-kind}"
 }
 
-check_kind
-setup_kind_cluster
+# run commands or install
+case "${1:-}" in
+  "check")
+    check_kind
+    ;;
+  "metallb")
+    echo "installing metallb"
+    install_metallb
+    echo "✅ metallb installed"
+    ;;
+  *)
+    setup_kind_cluster
+    ;;
+esac
+
+# check_kind
+# setup_kind_cluster

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+################################
+# Makes sure the given commands are installed
+# before continuing.
+# Globals:
+#   None
+# Arguments:
+#   args: (list) commands to check for
+# Returns:
+#  0 if all commands are installed, 1 otherwise
+################################
+function check_cmd() {
+	for cmd in "$@"; do
+		if ! command -v $cmd >/dev/null 2>&1; then
+			echo "Error: $cmd is not installed"
+			exit 1
+		fi
+	done
+}
+
+######################################
+# Installs MetalLB into the default namespace
+# for the current cluster.
+# Globals:
+#  None
+# Arguments:
+#  None
+# Returns:
+#  1 if MetalLB is not installed, 0 otherwise
+######################################
+function install_metallb() {
+  echo "launched install metallb"
+  local metalLBVersion='v0.12.1'
+  local metalLBManifests="https://raw.githubusercontent.com/metallb/metallb/${metalLBVersion}/manifests"
+  local metalLBNamespaceURL="${metalLBManifests}/namespace.yaml"
+  local metalLBURL="${metalLBManifests}/metallb.yaml"
+  local metalLBNamespace="metallb-system"
+
+  # create the metallb namespace
+  if ! [[ $(kubectl apply -f "${metalLBNamespaceURL}") ]]; then
+    echo "Failed to create metallb namespace"
+    return 1
+  fi
+
+  # create the manifest
+  if ! [[ $(kubectl apply -f "${metalLBURL}") ]]; then
+    echo "Failed to create metallb manifest"
+    return 1
+  fi
+
+  # wait for all pods with the label 'app=metallb' to be ready
+  echo "💤 Sleeping for 30 seconds to allow the metallb namespace to be initialized"
+  echo "📦 Waiting for pods to be ready..."
+  sleep 30
+  kubectl wait --for=condition=ready pod -l app=metallb -n "${metalLBNamespace}"
+
+  # allocate a group of subnets to be used for the MetalLB instances
+  echo "📢 Allocating network addresses"
+  local ipamConfig=$(docker network inspect -f '{{.IPAM.Config}}' kind)
+  local subnet=$(echo "${ipamConfig}" | awk '{ print $1 }')
+  local regex="([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/([0-9]+)"
+  if ! [[ $subnet =~ $regex ]]; then
+    echo "could not match"
+    return 1
+  fi
+
+  # create the subnets in MetalLB
+  local net1="${BASH_REMATCH[1]}"
+  local net2="${BASH_REMATCH[2]}"
+  local net3="${BASH_REMATCH[3]}"
+  local net4="${BASH_REMATCH[4]}"
+  local subnetMask="${BASH_REMATCH[5]}"
+
+  if ! [[ "${subnetMask}" -eq "16" ]]; then
+    echo "subnet unsupported"
+    return 1
+  fi
+
+  # create a single subnet, grant 255 addresses to LB
+  cat <<END | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - ${net1}.${net2}.255.0-${net1}.${net2}.255.255
+END
+}


### PR DESCRIPTION
This PR adds code which automatically [configures metallb](https://kind.sigs.k8s.io/docs/user/loadbalancer/) in the local KIND cluster.
This allows IPFS Cluster to be tested using both ClusterIP as well as a LoadBalancer.