### PR TITLE
Swarm.EnableHolePunching -> false

### DIFF
--- a/controllers/scripts/ipfs.go
+++ b/controllers/scripts/ipfs.go
@@ -209,7 +209,7 @@ func applyIPFSClusterK8sDefaults(conf *config.Config, storageMax string, peers [
 	conf.Datastore.BloomFilterSize = 1048576
 	conf.Datastore.StorageMax = storageMax
 	conf.Addresses.Swarm = []string{"/ip4/0.0.0.0/tcp/4001", "/ip6/::/tcp/4001"}
-	conf.Swarm.EnableHolePunching = config.True
+	conf.Swarm.EnableHolePunching = config.False
 	conf.Swarm.RelayClient = rc
 	conf.Peering.Peers = peers
 }


### PR DESCRIPTION
This sets `Swarm.EnableHolePunching` to false.
Fixes #38 
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>