### PR TITLE
Create Unique Identities for IPFS Containers

### DIFF
--- a/controllers/ipfs_controller.go
+++ b/controllers/ipfs_controller.go
@@ -143,9 +143,10 @@ func (r *IpfsReconciler) createTrackedObjects(
 
 	mutsa := r.serviceAccount(instance, &sa)
 	mutsvc, svcName := r.serviceCluster(instance, &svc)
+
 	mutCmScripts, cmScriptName := r.ConfigMapScripts(ctx, instance, &cmScripts)
+	mutSecConfig, secConfigName := r.secretConfig(ctx, instance, &secConfig, []byte(clusterSecret), []byte(privateString))
 	mutCmConfig, cmConfigName := r.configMapConfig(instance, &cmConfig, peerID.String())
-	mutSecConfig, secConfigName := r.secretConfig(instance, &secConfig, []byte(clusterSecret), []byte(privateString))
 	mutSts := r.statefulSet(instance, &sts, svcName, secConfigName, cmConfigName, cmScriptName)
 
 	trackedObjects := map[client.Object]controllerutil.MutateFn{

--- a/controllers/scripts/config.go
+++ b/controllers/scripts/config.go
@@ -17,24 +17,6 @@ type configureIpfsOpts struct {
 	FlattenedConfig string
 }
 
-/*
-
- 2 nodes
- key 1 - pk 1 => ipfs-1
- key 2 - pk 2 => ipfs-2
-
- secret{
-	ipfs-1: <data>
-	ipfs-2: <data>
-	...
- }
-
- container{
-	ipfs1 mounts secret, pulls ipfs-1
- }
-
-*/
-
 const (
 	configureIpfs = `
 #!/bin/sh
@@ -266,9 +248,6 @@ func createTemplateConfig(
 ) (conf config.Config, err error) {
 	// attempt to generate an identity
 
-	if err != nil {
-		return
-	}
 	// set keys + defaults
 	conf.Identity.PeerID = "_peer-id_"
 	conf.Identity.PrivKey = "_private-key_"

--- a/controllers/scripts/config.go
+++ b/controllers/scripts/config.go
@@ -188,7 +188,7 @@ func applyFlatfsServer(conf *config.Config) error {
 
 // setFlatfsShardFunc Attempts to update the given flatfs configuration to use a shardFunc
 // with the given `n`. If unsuccessful, false will be returned.
-func setFlatfsShardFunc(conf *config.Config, n uint8) error {
+func setFlatfsShardFunc(conf *config.Config, n int8) error {
 	// we want to use next-to-last/3 as the sharding function
 	// as per this issue:
 	// https://github.com/redhat-et/ipfs-operator/issues/32
@@ -216,7 +216,7 @@ func setFlatfsShardFunc(conf *config.Config, n uint8) error {
 			continue
 		}
 		if dsType == "flatfs" {
-			child["shardFunc"] = "/repo/flatfs/shard/v1/next-to-last/" + strconv.FormatUint(uint64(n), 10)
+			child["shardFunc"] = "/repo/flatfs/shard/v1/next-to-last/" + strconv.FormatInt(int64(n), 10)
 			break
 		}
 	}

--- a/controllers/scripts/config.go
+++ b/controllers/scripts/config.go
@@ -57,8 +57,8 @@ if [[ -f /data/ipfs/config ]]; then
 fi
 
 echo '{{ .FlattenedConfig }}' > config.json
-sed -i s/_peer-id_/"${PEER_ID}"/g
-sed -i s/_private-key_/"${PRIVATE_KEY}"/g
+sed -i s,_peer-id_,"${PEER_ID}",g config.json
+sed -i s,_private-key_,"${PRIVATE_KEY}",g config.json
 
 ipfs init -- config.json
 

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -43,14 +43,15 @@ func (r *IpfsReconciler) secretConfig(
 	}
 	// initialize the secret, if needed
 	if err != nil && errors.IsNotFound(err) {
+		expectedSecret.Data = make(map[string][]byte, 0)
+		expectedSecret.StringData = make(map[string]string, 0)
 		// secret doesn't exist
 		generateNewIdentities(expectedSecret, 0, m.Spec.Replicas)
-		expectedSecret.Data = make(map[string][]byte)
 		expectedSecret.Data["CLUSTER_SECRET"] = clusterSecret
 		expectedSecret.Data["BOOTSTRAP_PEER_PRIV_KEY"] = bootstrapPrivateKey
 	}
 
-	// secret does exist,
+	// secret does exist
 	numIdentities := countIdentities(expectedSecret)
 	if numIdentities != m.Spec.Replicas {
 		// create more identities if needed, otherwise they will be reused
@@ -86,7 +87,6 @@ func countIdentities(secret *corev1.Secret) int32 {
 // generateNewIdentities Populates the secret data with new Peer IDs
 // and private keys which are mapped based on the replica number.
 func generateNewIdentities(secret *corev1.Secret, start, n int32) error {
-	secret.StringData = make(map[string]string)
 	for i := start; i < n; i++ {
 		// generate new private key & peer id
 		peerID, privKey, err := generateIdentity()

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -1,12 +1,23 @@
 package controllers
 
 import (
+	"context"
+	"strconv"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterv1alpha1 "github.com/redhat-et/ipfs-operator/api/v1alpha1"
+)
+
+const (
+	peerIDPrefix     = "peerID-"
+	privateKeyPrefix = "privateKey-"
 )
 
 func (r *IpfsReconciler) secretConfig(
@@ -16,22 +27,74 @@ func (r *IpfsReconciler) secretConfig(
 	bootstrapPrivateKey []byte,
 ) (controllerutil.MutateFn, string) {
 	secName := "ipfs-cluster-" + m.Name
-	expected := &corev1.Secret{
+
+	expectedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secName,
 			Namespace: m.Namespace,
 		},
-		Data: map[string][]byte{
-			"CLUSTER_SECRET":          clusterSecret,
-			"BOOTSTRAP_PEER_PRIV_KEY": bootstrapPrivateKey,
-		},
 	}
-	expected.DeepCopyInto(sec)
+	// find secret
+	err := r.Get(context.Background(), client.ObjectKeyFromObject(expectedSecret), expectedSecret)
+	if err != nil && !errors.IsNotFound(err) {
+		return func() error {
+			return err
+		}, ""
+	}
+	// initialize the secret, if needed
+	if err != nil && errors.IsNotFound(err) {
+		// secret doesn't exist
+		generateNewIdentities(expectedSecret, 0, m.Spec.Replicas)
+		expectedSecret.Data["CLUSTER_SECRET"] = clusterSecret
+		expectedSecret.Data["BOOTSTRAP_PEER_PRIV_KEY"] = bootstrapPrivateKey
+	}
+
+	// secret does exist,
+	numIdentities := countIdentities(expectedSecret)
+	if numIdentities != m.Spec.Replicas {
+		// create more identities if needed, otherwise they will be reused
+		// when scaling down and then up again
+		if int(numIdentities) < int(m.Spec.Replicas) {
+			// create more
+			generateNewIdentities(expectedSecret, numIdentities, m.Spec.Replicas)
+		}
+	}
+
+	expectedSecret.DeepCopyInto(sec)
 	// FIXME: catch this error before we run the function being returned
 	if err := ctrl.SetControllerReference(m, sec, r.Scheme); err != nil {
 		return func() error { return err }, ""
 	}
 	return func() error {
+		sec.Data = expectedSecret.Data
 		return nil
 	}, secName
+}
+
+// countIdentities Counts the amount of unique peer identities present in the secret.
+func countIdentities(secret *corev1.Secret) int32 {
+	var count int32 = 0
+	for key := range secret.Data {
+		if strings.Contains(key, peerIDPrefix) {
+			count++
+		}
+	}
+	return count
+}
+
+// generateNewIdentities Populates the secret data with new Peer IDs
+// and private keys which are mapped based on the replica number.
+func generateNewIdentities(secret *corev1.Secret, start, n int32) error {
+	for i := start; i < n; i++ {
+		// generate new private key & peer id
+		peerID, privKey, err := generateIdentity()
+		if err != nil {
+			return err
+		}
+		peerIDKey := peerIDPrefix + strconv.Itoa(int(i))
+		secret.StringData[peerIDKey] = peerID.String()
+		secretKey := privateKeyPrefix + strconv.Itoa(int(i))
+		secret.StringData[secretKey] = privKey
+	}
+	return nil
 }

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -66,7 +66,7 @@ func (r *IpfsReconciler) secretConfig(
 	if numIdentities != m.Spec.Replicas {
 		// create more identities if needed, otherwise they will be reused
 		// when scaling down and then up again
-		if int(numIdentities) < int(m.Spec.Replicas) {
+		if numIdentities < m.Spec.Replicas {
 			// create more
 			err = generateNewIdentities(expectedSecret, numIdentities, m.Spec.Replicas)
 			if err != nil {

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -45,6 +45,7 @@ func (r *IpfsReconciler) secretConfig(
 	if err != nil && errors.IsNotFound(err) {
 		// secret doesn't exist
 		generateNewIdentities(expectedSecret, 0, m.Spec.Replicas)
+		expectedSecret.Data = make(map[string][]byte)
 		expectedSecret.Data["CLUSTER_SECRET"] = clusterSecret
 		expectedSecret.Data["BOOTSTRAP_PEER_PRIV_KEY"] = bootstrapPrivateKey
 	}
@@ -85,6 +86,7 @@ func countIdentities(secret *corev1.Secret) int32 {
 // generateNewIdentities Populates the secret data with new Peer IDs
 // and private keys which are mapped based on the replica number.
 func generateNewIdentities(secret *corev1.Secret, start, n int32) error {
+	secret.StringData = make(map[string]string)
 	for i := start; i < n; i++ {
 		// generate new private key & peer id
 		peerID, privKey, err := generateIdentity()

--- a/controllers/statefulset.go
+++ b/controllers/statefulset.go
@@ -101,6 +101,10 @@ func (r *IpfsReconciler) statefulSet(m *clusterv1alpha1.Ipfs,
 									Name:      "configure-script",
 									MountPath: "custom",
 								},
+								{
+									Name:      "ipfs-node-data",
+									MountPath: "/node-data",
+								},
 							},
 						},
 					},
@@ -262,6 +266,14 @@ func (r *IpfsReconciler) statefulSet(m *clusterv1alpha1.Ipfs,
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: configMapBootstrapScriptName,
 									},
+								},
+							},
+						},
+						{
+							Name: "ipfs-node-data",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: secretName,
 								},
 							},
 						},


### PR DESCRIPTION
This PR fixes a bug introduced in #51 which assigned every Kubo node the same identity when the Operator switched over to generating identities for each node on the controller-side.

Now we use the `generateIdentity` function, which gives us a peer ID and private key. These two values are stored in the generated secret, and map to their corresponding replica. 
The keys are of the format `peerID-<k>` and `privateKey-<k>`, where $0 \le k < numReplicas$.

The Kubernetes spec only allows for secrets to be a maximum size of `1MiB`, so we will need to find a workaround in order to scale up to an arbitrary amount of nodes. One solution could be to encode the keys as singular values, and then shard them across several secrets.